### PR TITLE
Only add thirdparty optional JS to the page if it is in use.

### DIFF
--- a/generators/app/templates/config.js
+++ b/generators/app/templates/config.js
@@ -5,6 +5,8 @@ var config = {
       url: process.env.SITE_URL || 'http://example.com', // full site url
       title: '<%= name %>',
       comments: true,
+      // @todo complete support for social icons.
+      show_social_icons: false,
       disqus: process.env.DISQUS || 'example',
       googleAnalytics: process.env.GOOGLE_ANALYTICS || '123457'
     }
@@ -15,6 +17,8 @@ var config = {
       url: process.env.DEV_SITE_URL || 'http://localhost:8000', // full site url
       title: '<%= name %>',
       comments: true,
+      // @todo complete support for social icons.
+      show_social_icons: false,
       disqus: process.env.DEV_DISQUS || 'staging-example',
       googleAnalytics: process.env.DEV_GOOGLE_ANALYTICS || '123456'
     }
@@ -22,6 +26,7 @@ var config = {
   social: {
     github_username: '',
     stackoverflow_id: '',
+    // Exclude @-prefix.
     twitter_username: '',
     google_plus_id: '',
     email: '',

--- a/generators/app/templates/ironsmith.js
+++ b/generators/app/templates/ironsmith.js
@@ -31,6 +31,7 @@ module.exports = function (production) {
   } else {
     configData = config.development;
   }
+  configData.social = config.social;
 
   return Metalsmith(__dirname)
     .clean(false)

--- a/generators/app/templates/pixyll/templates/partials/header.html
+++ b/generators/app/templates/pixyll/templates/partials/header.html
@@ -10,7 +10,7 @@
       </nav>
       <div class="clearfix"></div>
       {% if site.show_social_icons %}
-        {% include social_links.html %}
+        {% include 'social.html' %}
       {% endif %}
     </div>
   </div>

--- a/generators/app/templates/pixyll/templates/partials/social.html
+++ b/generators/app/templates/pixyll/templates/partials/social.html
@@ -6,7 +6,7 @@
     {% if social.stackoverflow_id %}
       <a class="fa fa-stack-overflow" href="https://stackoverflow.com/users/{{ social.stackoverflow_id }}"></a>
     {% endif %}
-    <a class="fa fa-rss" href="{{baseUrl}}/feed.xml"></a>
+    <a class="fa fa-rss" href="{{baseUrl}}/rss.xml"></a>
     {% if social.twitter_username %}
       <a class="fa fa-twitter" href="https://twitter.com/{{ social.twitter_username }}"></a>
     {% endif %}

--- a/generators/app/templates/pixyll/templates/post.html
+++ b/generators/app/templates/pixyll/templates/post.html
@@ -21,6 +21,7 @@
 {% endblock %}
 
 {% block thirdparty %}
+{% if site.comments && site.disqus || site.show_social_icons %}
 <script type="text/javascript">
   {% if site.comments && site.disqus %}
   // disqus
@@ -33,7 +34,10 @@
     (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
   })();
   {% endif %}
+  {% if site.show_social_icons %}
   // Twitter
   !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');
+  {% endif %}
 </script>
+{% endif %}
 {% endblock %}

--- a/generators/app/templates/pixyll/templates/post.html
+++ b/generators/app/templates/pixyll/templates/post.html
@@ -23,6 +23,7 @@
 {% block thirdparty %}
 <script type="text/javascript">
   // disqus
+  {% if site.comments && site.disqus %}
   var disqus_shortname = '{{site.disqus}}';
   var disqus_title = '{{title}}';
   var disqus_url = '{{site.url}}/{{path}}/';
@@ -31,9 +32,8 @@
     dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
     (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
   })();
+  {% endif %}
   // Twitter
   !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');
 </script>
 {% endblock %}
-
-

--- a/generators/app/templates/pixyll/templates/post.html
+++ b/generators/app/templates/pixyll/templates/post.html
@@ -22,8 +22,8 @@
 
 {% block thirdparty %}
 <script type="text/javascript">
-  // disqus
   {% if site.comments && site.disqus %}
+  // disqus
   var disqus_shortname = '{{site.disqus}}';
   var disqus_title = '{{title}}';
   var disqus_url = '{{site.url}}/{{path}}/';


### PR DESCRIPTION
- Only add Disqus JS if comments are enabled.
- Only add Twitter JS if social icons are enabled
- Only add thirdparty script block if one of the above is in use.
- Fix issues enabling and producing social menu on the page for purposes of testing the above.

This PR does not fix the issue of social icons actually display in the page.
